### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Unlike the official Kagi API which requires API access, this MCP server uses you
 
 _"Kagi-ken"_ is a portmanteau of _"Kagi"_ (the service) and _"token"_.
 
+<a href="https://glama.ai/mcp/servers/@czottmann/kagi-ken-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@czottmann/kagi-ken-mcp/badge" alt="kagi-kan-mcp MCP server" />
+</a>
 
 ## Why?
 


### PR DESCRIPTION
This PR adds a badge for the [kagi-kan-mcp](https://glama.ai/mcp/servers/@czottmann/kagi-ken-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@czottmann/kagi-ken-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@czottmann/kagi-ken-mcp/badge" alt="kagi-kan-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.